### PR TITLE
Fix to rotate CameraImage

### DIFF
--- a/example/lib/ui/camera_view.dart
+++ b/example/lib/ui/camera_view.dart
@@ -187,7 +187,7 @@ class _CameraViewState extends State<CameraView> with WidgetsBindingObserver {
       Stopwatch stopwatch = Stopwatch()..start();
 
       String imageClassification = await _imageModel!
-          .getCameraImagePrediction(cameraImage, _camFrameRotation);
+          .getCameraImagePrediction(cameraImage, rotation: _camFrameRotation);
       // Stop the stopwatch
       stopwatch.stop();
       // print("imageClassification $imageClassification");
@@ -221,7 +221,7 @@ class _CameraViewState extends State<CameraView> with WidgetsBindingObserver {
       List<ResultObjectDetection> objDetect =
           await _objectModel!.getCameraImagePrediction(
         cameraImage,
-        _camFrameRotation,
+        rotation: _camFrameRotation,
         minimumScore: 0.3,
         iOUThreshold: 0.3,
       );

--- a/lib/image_utils_isolate.dart
+++ b/lib/image_utils_isolate.dart
@@ -52,15 +52,15 @@ class ImageUtilsIsolate {
     }
 
     if (image != null) {
-      if (Platform.isIOS) {
-        // ios, default camera image is portrait view
-        // rotate 270 to the view that top is on the left, bottom is on the right
-        // image ^4.0.17 error here
-        image = copyRotate(image, angle: 270);
-      }
-      if (Platform.isAndroid) {
-        image = copyRotate(image, angle: 90);
-      }
+      // if (Platform.isIOS) {
+      //   // ios, default camera image is portrait view
+      //   // rotate 270 to the view that top is on the left, bottom is on the right
+      //   // image ^4.0.17 error here
+      //   image = copyRotate(image, angle: 270);
+      // }
+      // if (Platform.isAndroid) {
+      //   image = copyRotate(image, angle: 90);
+      // }
       return TransferableTypedData.fromList([encodeJpg(image)]);
     }
     return null;

--- a/lib/pytorch_lite.dart
+++ b/lib/pytorch_lite.dart
@@ -347,10 +347,9 @@ class ClassificationModel {
   /// [cameraPreProcessingMethod], and [preProcessingMethod].
   /// Returns a [Future] that resolves to a [List] of [double] values representing the predictions.
   /// Throws an [Exception] if unable to process the image bytes.
-  Future<List<double>> getCameraImagePredictionList(
-      CameraImage cameraImage,
+  Future<List<double>> getCameraImagePredictionList(CameraImage cameraImage,
       {int? rotation,
-        List<double> mean = torchVisionNormMeanRGB,
+      List<double> mean = torchVisionNormMeanRGB,
       List<double> std = torchVisionNormSTDRGB,
       CameraPreProcessingMethod cameraPreProcessingMethod =
           CameraPreProcessingMethod.imageLib,
@@ -363,14 +362,7 @@ class ClassificationModel {
       if (bytes == null) {
         throw Exception("Unable to process image bytes");
       }
-      rotation ??= Platform.isAndroid ? 90 : 0;
-      if (rotation != 0) {
-        try {
-          bytes = _rotateImageBytes(bytes, rotation);
-        } catch (error, _) {
-          rethrow;
-        }
-      }
+
       // Retrieve the image predictions for the preprocessed image bytes
       return await getImagePredictionList(bytes,
           mean: mean, std: std, preProcessingMethod: preProcessingMethod);
@@ -390,7 +382,8 @@ class ClassificationModel {
   /// [cameraPreProcessingMethod], and [preProcessingMethod].
   /// Returns a [Future] that resolves to a [String] representing the top prediction label.
   Future<String> getCameraImagePrediction(CameraImage cameraImage,
-      {int? rotation, List<double> mean = torchVisionNormMeanRGB,
+      {int? rotation,
+      List<double> mean = torchVisionNormMeanRGB,
       List<double> std = torchVisionNormSTDRGB,
       CameraPreProcessingMethod cameraPreProcessingMethod =
           CameraPreProcessingMethod.imageLib,
@@ -419,7 +412,7 @@ class ClassificationModel {
   Future<List<double>> getCameraImagePredictionProbabilities(
       CameraImage cameraImage,
       {int? rotation,
-        List<double> mean = torchVisionNormMeanRGB,
+      List<double> mean = torchVisionNormMeanRGB,
       List<double> std = torchVisionNormSTDRGB,
       CameraPreProcessingMethod cameraPreProcessingMethod =
           CameraPreProcessingMethod.imageLib,
@@ -427,7 +420,8 @@ class ClassificationModel {
           PreProcessingMethod.imageLib}) async {
     // Retrieve the prediction list for the camera image
     final List<double> prediction = await getCameraImagePredictionList(
-        cameraImage, rotation: rotation,
+        cameraImage,
+        rotation: rotation,
         mean: mean,
         std: std,
         cameraPreProcessingMethod: cameraPreProcessingMethod,
@@ -607,7 +601,7 @@ class ModelObjectDetection {
   Future<List<ResultObjectDetection>> getCameraImagePredictionList(
       CameraImage cameraImage,
       {int? rotation,
-        double minimumScore = 0.5,
+      double minimumScore = 0.5,
       double iOUThreshold = 0.5,
       int boxesLimit = 10,
       CameraPreProcessingMethod cameraPreProcessingMethod =
@@ -621,14 +615,7 @@ class ModelObjectDetection {
       if (bytes == null) {
         throw Exception("Unable to process image bytes");
       }
-      rotation ??= Platform.isAndroid ? 90 : 0;
-      if (rotation != 0) {
-        try {
-          bytes = _rotateImageBytes(bytes, rotation);
-        } catch (error, _) {
-          rethrow;
-        }
-      }
+
       // Get the image prediction list using the converted bytes
       return await getImagePredictionList(bytes,
           minimumScore: minimumScore,
@@ -653,7 +640,7 @@ class ModelObjectDetection {
   Future<List<ResultObjectDetection>> getCameraImagePrediction(
       CameraImage cameraImage,
       {int? rotation,
-        double minimumScore = 0.5,
+      double minimumScore = 0.5,
       double iOUThreshold = 0.5,
       int boxesLimit = 10,
       CameraPreProcessingMethod cameraPreProcessingMethod =

--- a/lib/pytorch_lite.dart
+++ b/lib/pytorch_lite.dart
@@ -11,6 +11,7 @@ import 'package:pytorch_lite/enums/model_type.dart';
 import 'package:pytorch_lite/image_utils_isolate.dart';
 import 'package:pytorch_lite/pigeon.dart';
 import 'package:collection/collection.dart';
+import 'package:image/image.dart' as img;
 
 export 'enums/dtype.dart';
 export 'package:pytorch_lite/pigeon.dart';
@@ -595,6 +596,15 @@ class ModelObjectDetection {
       // Convert the camera image to bytes using ImageUtilsIsolate
       Uint8List? bytes =
           await ImageUtilsIsolate.convertCameraImageToBytes(cameraImage);
+
+      if (rotation != 0) {
+        try {
+          bytes = rotateImageBytes(bytes!, rotation);
+        } catch (error, _) {
+          rethrow;
+        }
+      }
+
       if (bytes == null) {
         throw Exception("Unable to process image bytes");
       }
@@ -637,6 +647,16 @@ class ModelObjectDetection {
             preProcessingMethod: preProcessingMethod);
     addLabels(prediction);
     return prediction;
+  }
+
+  Uint8List rotateImageBytes(Uint8List imageBytes, int rotation) {
+    img.Image? image = img.decodeImage(imageBytes);
+    if (image == null) {
+      throw Exception("Unable to decode image bytes");
+    }
+
+    img.Image rotatedImage = img.copyRotate(image, angle: rotation);
+    return Uint8List.fromList(img.encodeJpg(rotatedImage));
   }
 
   /// Renders a list of boxes on an image.


### PR DESCRIPTION
There were two fundamental problems in CameraImage processing.

1. The rotation parameter of getCameraImagePredictionList() is not used anywhere. Users imagine that the image will be rotated by the amount of value they input to the rotation argument, but it does not actually work.

2. In _convertCameraImageToBytes() of the image_utils_isolate.dart file, the camera image is forcibly rotated. Based on portrait mode, Android should rotate 90 degrees, and IOS should not rotate. Android has a code that rotates 90 degrees, so it is normal, but IOS has a code that rotates 270 degrees, so it works abnormally.

This is what I modified to fix it.

1. Comment out the rotation code inserted in _convertCameraImageToBytes().
-> The rotation action is not related to the method name, so it feels like a side effect, and it should rotate by the rotation value entered by the user, not a fixed value.

2. In the pytorch_lite.dart file, change all rotation arguments of camera_image related methods to named options and provide default values. Also, rotate the image by the rotation value passed.

-> In portrait mode, it works normally without entering a separate value, and the user can enter the rotation value as needed to get the desired result.